### PR TITLE
feat: add Apple login support

### DIFF
--- a/APPLE_LOGIN_INSTRUCTIONS.txt
+++ b/APPLE_LOGIN_INSTRUCTIONS.txt
@@ -1,0 +1,33 @@
+1. 애플 개발자 계정 가입 및 서비스 설정
+   - Apple Developer 계정에 로그인합니다.
+   - Certificates, Identifiers & Profiles 메뉴에서 "Identifiers"를 선택합니다.
+   - "+" 버튼을 눌러 새로운 Service ID(웹용) 또는 App ID(앱용)를 생성합니다.
+   - Description과 Identifier를 입력 후 Sign In with Apple 기능을 활성화합니다.
+
+2. 키 발급(Key ID 생성)
+   - 같은 메뉴의 "Keys"에서 "+" 버튼을 눌러 새로운 키를 생성합니다.
+   - Sign In with Apple을 선택하고, 앞서 만든 Identifier를 연결합니다.
+   - Key를 다운로드하면 한 번만 제공되므로 안전한 곳에 보관합니다.
+
+3. Team ID 확인
+   - Apple Developer 계정의 Membership 페이지에서 Team ID를 확인할 수 있습니다.
+
+4. 환경 변수 설정(.env)
+   - 프로젝트 루트의 .env 파일에 아래 값을 설정합니다.
+     APPLE_CLIENT_ID="발급받은 Identifier"
+     APPLE_TEAM_ID="Team ID"
+     APPLE_PRIVATE_KEY="다운로드한 키의 내용 (줄바꿈을 \n으로 치환)"
+     APPLE_KEY_ID="Key ID"
+   - 실제 배포 환경에서는 위 값들을 안전하게 관리해야 합니다.
+
+5. NextAuth Provider 추가
+   - src/app/api/auth/[...nextauth]/route.ts 파일의 providers 배열에 AppleProvider를 추가합니다.
+   - 이미 코드에 예시가 포함되어 있으니 환경 변수만 실제 값으로 교체하면 됩니다.
+
+6. 프론트엔드 버튼 확인
+   - /auth 페이지에서 Google 아래에 Apple 로그인 버튼이 노출되는지 확인합니다.
+   - 버튼 클릭 시 애플 로그인 화면으로 이동하는지 테스트합니다.
+
+7. 백엔드 연동 확인
+   - 로그인 성공 시 users 컬렉션에 사용자가 생성되는지 확인합니다.
+   - mypage에서 사용자 데이터가 정상적으로 조회되는지 검증합니다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3149,21 +3149,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.4.tgz",
-      "integrity": "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,5 +1,6 @@
 import NextAuth from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
+import AppleProvider from 'next-auth/providers/apple';
 import clientPromise from '@/lib/mongodb';
 
 /**
@@ -11,6 +12,19 @@ const handler = NextAuth({
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID || "",
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || "",
+    }),
+    // 🛠 애플 로그인 설정 (아래 환경 변수에 실제 값을 설정해야 합니다)
+    // TODO: 애플 개발자 계정에서 발급받은 값들로 환경 변수를 설정하세요.
+    AppleProvider({
+      clientId: process.env.APPLE_CLIENT_ID || "APPLE_CLIENT_ID",
+      clientSecret: {
+        // 애플 팀 ID
+        teamId: process.env.APPLE_TEAM_ID || "TEAM_ID",
+        // 애플에서 발급받은 Private Key (줄바꿈 문자를 \n으로 치환하여 환경 변수에 저장)
+        privateKey: process.env.APPLE_PRIVATE_KEY || "APPLE_PRIVATE_KEY",
+        // Key ID
+        keyId: process.env.APPLE_KEY_ID || "KEY_ID",
+      },
     }),
   ],
   
@@ -49,6 +63,7 @@ const handler = NextAuth({
 
     /**
      * 사용자 로그인 시 users 컬렉션에 저장
+     * Google/Apple 등 모든 OAuth Provider에서 동일하게 동작합니다.
      */
     async signIn({ user, account, profile }) {
       try {

--- a/src/app/auth/Auth.tsx
+++ b/src/app/auth/Auth.tsx
@@ -7,7 +7,7 @@ import "@/styles/auth/auth.css";
 
 /**
  * 로그인 페이지 메인 컴포넌트
- * Google OAuth를 통한 사용자 로그인 기능을 제공합니다.
+ * Google / Apple OAuth를 통한 사용자 로그인 기능을 제공합니다.
  */
 export default function LoginContent() {
   // 로그인 제공자 목록을 저장하는 상태
@@ -47,21 +47,36 @@ export default function LoginContent() {
       <div className="login-card">
         <h1 className="login-title">로그인</h1>
 
-        {/* 로그인 제공자가 있는 경우 로그인 버튼들을 표시 */}
-        {providers && Object.values(providers).map((provider: any) => (
-          <button
-            key={provider.id}
-            onClick={() => handleProviderSignIn(provider.id)}
-            disabled={isLoading}
-            className={`login-button ${
-              provider.id === "google" ? "login-button--google" : "login-button--default"
-            } ${isLoading ? "login-button--loading" : ""}`}
-          >
-            {/* 구글 로그인 버튼에는 아이콘 추가 */}
-            {provider.id === "google" && "🔗"}
-            {isLoading ? "로그인 중..." : `${provider.name}으로 로그인`}
-          </button>
-        ))}
+          {/* 로그인 제공자가 있는 경우 Google과 Apple 로그인 버튼을 표시 */}
+          {providers && (
+            <>
+              {providers.google && (
+                <button
+                  onClick={() => handleProviderSignIn(providers.google.id)}
+                  disabled={isLoading}
+                  className={`login-button login-button--google ${
+                    isLoading ? "login-button--loading" : ""
+                  }`}
+                >
+                  {/* 구글 로그인 버튼에는 아이콘 추가 */}
+                  🔗{isLoading ? "로그인 중..." : ` ${providers.google.name}으로 로그인`}
+                </button>
+              )}
+
+              {providers.apple && (
+                <button
+                  onClick={() => handleProviderSignIn(providers.apple.id)}
+                  disabled={isLoading}
+                  className={`login-button login-button--apple ${
+                    isLoading ? "login-button--loading" : ""
+                  }`}
+                >
+                  {/* 애플 로그인 버튼 */}
+                  {isLoading ? "로그인 중..." : ` ${providers.apple.name}으로 로그인`}
+                </button>
+              )}
+            </>
+          )}
 
         {/* 홈으로 돌아가기 링크 */}
         <div className="home-link-container">

--- a/src/styles/auth/auth.css
+++ b/src/styles/auth/auth.css
@@ -44,17 +44,23 @@
   transition: opacity 0.2s ease;
 }
 
-/* 구글 로그인 버튼 */
-.login-button--google {
-  background-color: #db4437;
-  color: white;
-}
+  /* 구글 로그인 버튼 */
+  .login-button--google {
+    background-color: #db4437;
+    color: white;
+  }
 
-/* 기본 로그인 버튼 */
-.login-button--default {
-  background-color: #333;
-  color: white;
-}
+  /* 애플 로그인 버튼 */
+  .login-button--apple {
+    background-color: #000;
+    color: white;
+  }
+
+  /* 기본 로그인 버튼 */
+  .login-button--default {
+    background-color: #333;
+    color: white;
+  }
 
 /* 로딩 상태 버튼 */
 .login-button--loading {


### PR DESCRIPTION
## Summary
- add Apple provider to NextAuth configuration with placeholders
- show Apple login button and styling
- document Apple login setup steps

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68993aba7c0883288b5e06f8370d7726